### PR TITLE
feat: Fees estimation

### DIFF
--- a/api/fees.ts
+++ b/api/fees.ts
@@ -1,0 +1,119 @@
+import { NowRequest, NowResponse } from "@vercel/node";
+import axios from "axios";
+
+interface Network {
+  totalTxs: number;
+  totalGasUsed: number;
+  totalGas: number;
+  totalGasUSDT: number;
+  avgGasUsed: number;
+  avgGasUSDT: number;
+  minGasPrice: number;
+  maxGasPrice: number;
+  totalFailedTxs: number;
+  totalFailedGas: number;
+}
+
+interface Transaction {
+  blockNumber: string;
+  timeStamp: string;
+  hash: string;
+  nonce: string;
+  blockHash: string;
+  transactionIndex: string;
+  from: string;
+  to: string;
+  value: string;
+  gas: string;
+  gasPrice: string;
+  isError: string;
+  txreceipt_status: string;
+  input: string;
+  contractAddress: string;
+  cumulativeGasUsed: string;
+  gasUsed: string;
+  confirmations: string;
+}
+
+const getPrice = async (symbol: string) => {
+  const request = await axios.get("https://api.binance.com/api/v3/avgPrice", {
+    params: {
+      symbol,
+    },
+  });
+
+  const { price } = request.data;
+  return price;
+};
+
+const getTxs = async (baseDomain: string, address: string) => {
+  const request = await axios.get(`https://api.${baseDomain}/api`, {
+    params: {
+      module: "account",
+      action: "txlist",
+      address,
+      startblock: 0,
+      endblock: 99999999,
+      sort: "desc",
+      apikey: process.env.API_KEY,
+    },
+  });
+
+  const { result } = request.data;
+  return result;
+};
+
+const getStatForNetwork = async (network: string, address: string): Promise<Network> => {
+  const baseDomain = network === "ETH" ? "etherscan.io" : "bscscan.com";
+  const symbol = network === "ETH" ? "ETHUSDT" : "BNBUSDT";
+
+  const price = await getPrice(symbol);
+
+  const txs = await getTxs(baseDomain, address);
+  const succeeded = txs.filter((tx: Transaction) => tx.from === address.toLowerCase());
+  const failed = txs.filter((tx: Transaction) => tx.isError === "1");
+
+  // Succeeded transactions.
+  const totalTxs = succeeded.length;
+  const gasUsed = succeeded.map((tx: Transaction) => parseInt(tx.gasUsed));
+  const gasPrice = succeeded.map((tx: Transaction) => parseInt(tx.gasPrice));
+  const totalGas =
+    succeeded.reduce((acc: number, tx: Transaction) => acc + parseInt(tx.gasUsed) * parseInt(tx.gasPrice), 0) / 1e18;
+  const totalGasUSDT =
+    (succeeded.reduce((acc: number, tx: Transaction) => acc + parseInt(tx.gasUsed) * parseInt(tx.gasPrice), 0) / 1e18) *
+    price;
+  const totalGasUsed = gasUsed.reduce((acc: number, value: number) => acc + value, 0);
+  const totalGasPrice = gasPrice.reduce((acc: number, value: number) => acc + value, 0);
+  const avgGasUsed = totalGasPrice / totalTxs / 1e9;
+  const avgGasUSDT = totalGasUSDT / totalTxs;
+  const minGasPrice = Math.min(...gasPrice) / 1e9;
+  const maxGasPrice = Math.max(...gasPrice) / 1e9;
+
+  // Failed transaction.
+  const totalFailedTxs = failed.length;
+  const totalFailedGas =
+    failed.reduce((acc: number, tx: Transaction) => acc + parseInt(tx.gasUsed) * parseInt(tx.gasPrice), 0) / 1e18;
+
+  return {
+    totalTxs,
+    totalGasUsed,
+    totalGas,
+    totalGasUSDT,
+    avgGasUsed,
+    avgGasUSDT,
+    minGasPrice,
+    maxGasPrice,
+    totalFailedTxs,
+    totalFailedGas,
+  };
+};
+
+export default async (req: NowRequest, res: NowResponse) => {
+  const { address } = req.query;
+
+  const ethNetwork = await getStatForNetwork("ETH", address as string);
+  const bscNetwork = await getStatForNetwork("BSC", address as string);
+  const cheaper = Math.round(ethNetwork.avgGasUSDT / bscNetwork.avgGasUSDT);
+
+  res.json({ address, eth: ethNetwork, bsc: bscNetwork, cheaper });
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
     "gatsby": "^2.18.14",
     "gatsby-image": "^2.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,6 +2820,13 @@ axios@^0.20.0:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"


### PR DESCRIPTION
Endpoint to calculate fees from Binance Smart Chain transactions; and estimate equivalent ETH fees based on the same transactions array.
Transactions taken into account are both succesfull and failed, and only from the sender's address.

BSC transactions are pulled from BscScan.
ETH gas fee is pulled from Etherscan.
BNB / ETH prices are pulled from Binance (on USDT quote pair).

Example response:
```json
{
    "address": "0x........",
    "chains": {
        "bsc": {
            "totalTxs": 92,
            "totalGasUsed": 8226307,
            "totalGas": 0.17373462,
            "totalGasUSDT": 7.76,
            "avgGasUsed": 24,
            "avgGasUSDT": 0.08
        },
        "eth": {
            "totalTxs": 92,
            "totalGasUsed": 8226307,
            "totalGas": 0.54293626,
            "totalGasUSDT": 668.71,
            "avgGasUsed": 66,
            "avgGasUSDT": 7.26
        }
    }
}
```